### PR TITLE
upgrade geotools 14.1 -> 14.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     
     <properties>
         <project.build.sourceEncoding>windows-1252</project.build.sourceEncoding>
-        <geotools.version>14.1</geotools.version>
+        <geotools.version>14.5</geotools.version>
     </properties>
     
     <dependencies>


### PR DESCRIPTION
Voor Flamingo willen we een versie waar geotools in-sync is, dit is een upgrade naar de laatste 14.x (bug-fix) release

mogelijk kan de com.vividsolutions:jts dependency eruit; geotools brengt die ook mee.

zie ook: flamingo-geocms/flamingo#620 en flamingo-geocms/flamingo#674
