### PR TITLE
Aanpassingen HTTP post naar geonetwork

### DIFF
--- a/src/main/java/nl/b3p/csw/client/CswClient.java
+++ b/src/main/java/nl/b3p/csw/client/CswClient.java
@@ -118,8 +118,9 @@ public class CswClient {
     }
 
     protected Document doRequest(JAXBElement jaxbElement, boolean transaction) throws IOException, JDOMException, JAXBException, OwsException {
-        if (jaxbElement == null)
+        if (jaxbElement == null) {
             throw new IllegalArgumentException("Provided jaxbElement must be non-null.");
+        }
 
         log.debug(MarshallUtil.marshall(jaxbElement, null));
         String marshalledCswXml = MarshallUtil.marshall(jaxbElement, cswSchema);

--- a/src/main/java/nl/b3p/csw/server/GeoNetworkCswServer.java
+++ b/src/main/java/nl/b3p/csw/server/GeoNetworkCswServer.java
@@ -5,6 +5,7 @@
 package nl.b3p.csw.server;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import javax.xml.bind.JAXBException;
 import nl.b3p.commons.services.B3PCredentials;
 import nl.b3p.commons.services.HttpClientConfigured;
@@ -179,7 +180,7 @@ public class GeoNetworkCswServer implements CswServable<Document> {
         post.addHeader(HttpHeaders.ACCEPT, "text/xml");
         post.addHeader(HttpHeaders.ACCEPT_CHARSET, "utf-8");
         post.addHeader(HttpHeaders.CONTENT_ENCODING, "utf-8");
-        post.setEntity(new StringEntity(request, ContentType.TEXT_XML));
+        post.setEntity(new StringEntity(request, ContentType.create("text/xml", Charset.forName("utf-8"))));
 
         HttpResponse response = hcc.execute(post);
 

--- a/src/main/java/nl/b3p/csw/server/GeoNetworkCswServer.java
+++ b/src/main/java/nl/b3p/csw/server/GeoNetworkCswServer.java
@@ -14,6 +14,7 @@ import nl.b3p.csw.client.ResponseListenable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.methods.HttpPost;
@@ -175,7 +176,9 @@ public class GeoNetworkCswServer implements CswServable<Document> {
             context.setCookieStore(cookieStore);
         }
         HttpPost post = new HttpPost(url);
-        post.addHeader("Accept", "text/xml");
+        post.addHeader(HttpHeaders.ACCEPT, "text/xml");
+        post.addHeader(HttpHeaders.ACCEPT_CHARSET, "utf-8");
+        post.addHeader(HttpHeaders.CONTENT_ENCODING, "utf-8");
         post.setEntity(new StringEntity(request, ContentType.TEXT_XML));
 
         HttpResponse response = hcc.execute(post);


### PR DESCRIPTION
werk voor B3Partners/B3pCatalog#5 zie B3Partners/B3pCatalog#4

- zet extra charset voor de post naar GNW
- Gebruik UTF-8 ipv de default (latin-1) die in de apache ContentType.TEXT_XML zit