### PR TITLE
GeoTools upgrade naar 24.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <maven.compiler.target>${project.build.targetVersion}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
-        <geotools.version>24-RC</geotools.version>
+        <geotools.version>24.0</geotools.version>
         <jts.version>1.17.1</jts.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>nl.b3p</groupId>
     <artifactId>b3p-commons-csw</artifactId>
-    <version>6.2.3-SNAPSHOT</version>
+    <version>6.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <url>https://github.com/B3Partners/${project.artifactId}/</url>
@@ -48,8 +48,8 @@
         <maven.compiler.target>${project.build.targetVersion}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
-        <geotools.version>23.2</geotools.version>
-        <jts.version>1.16.1</jts.version>
+        <geotools.version>24-RC</geotools.version>
+        <jts.version>1.17.1</jts.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
- [x] Bump JTS 1.16.1 ➜ 1.17.1 (closes #53 )
- [x] Bump GeoTools 23.2 ➜ 24-RC
- [x] Bump GeoTools 24-RC ➜ 24.0
